### PR TITLE
Update namespace to wizeworks and add ClusterIssuer for Let's Encrypt

### DIFF
--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: wize-comment
-  namespace: development
+  namespace: wizeworks
   labels:
     app: wize-comment
 spec:

--- a/deployment/ingress.yaml
+++ b/deployment/ingress.yaml
@@ -1,3 +1,17 @@
+kind: ClusterIssuer
+metadata:
+  name: wizeworks-encrypt
+spec:
+  acme:
+    email: support@jobsight.co
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: wizeworks-encrypt-account-key
+    solvers:
+      - http01:
+          ingress:
+            class: nginx
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/deployment/ingress.yaml
+++ b/deployment/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: wize-comment-ingress
-  namespace: development
+  namespace: wizeworks
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-brandonkorous

--- a/deployment/service.yaml
+++ b/deployment/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: wize-comment-service
-  namespace: development
+  namespace: wizeworks
   labels:
     app: wize-comment
 spec:


### PR DESCRIPTION
Change the namespace from development to wizeworks in deployment files and introduce a ClusterIssuer configuration for Let's Encrypt to manage SSL certificates.