### PR TITLE
Add apiVersion to ClusterIssuer in ingress configuration

### DIFF
--- a/deployment/ingress.yaml
+++ b/deployment/ingress.yaml
@@ -1,3 +1,4 @@
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: wizeworks-encrypt


### PR DESCRIPTION
Include the `apiVersion` field for the `ClusterIssuer` in the ingress configuration to ensure compatibility with cert-manager.