### PR TITLE
Update GraphQL factory version and reintroduce CommentModel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
     "name": "wize-comment",
-    "version": "0.1.0",
+    "version": "1.1.17",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "wize-comment",
-            "version": "0.1.0",
+            "version": "1.1.17",
             "license": "MIT",
             "dependencies": {
                 "@sentry/node": "^9.13.0",
                 "@sentry/profiling-node": "^9.13.0",
                 "@supabase/postgrest-js": "^1.19.4",
                 "@supabase/supabase-js": "^2.49.4",
-                "@wizeworks/graphql-factory": "^1.5.1",
+                "@wizeworks/graphql-factory": "^1.5.2",
                 "chalk": "^5.4.1",
                 "dotenv": "^16.5.0",
                 "fastify": "^5.3.0",
@@ -1557,9 +1557,9 @@
             }
         },
         "node_modules/@wizeworks/graphql-factory": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/@wizeworks/graphql-factory/-/graphql-factory-1.5.1.tgz",
-            "integrity": "sha512-WoNCnjyB5NN0TayUNs089aBDGtFbi9VatifemZCc3z5OLmYh0wk6+8ACA8euRS7wvH9GCslWpNLNDXXM3M0fng==",
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@wizeworks/graphql-factory/-/graphql-factory-1.5.2.tgz",
+            "integrity": "sha512-5p5nc9payoi5F18CWz4hWem1R1rg7syxjg/y3XKSIwwVJJirO/Vkh0B5Tqi/6ezB726g1HwMOmVrzSeDcMjweQ==",
             "license": "MIT",
             "dependencies": {
                 "@sentry/node": "^9.13.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "@sentry/profiling-node": "^9.13.0",
         "@supabase/postgrest-js": "^1.19.4",
         "@supabase/supabase-js": "^2.49.4",
-        "@wizeworks/graphql-factory": "^1.5.1",
+        "@wizeworks/graphql-factory": "^1.5.2",
         "chalk": "^5.4.1",
         "dotenv": "^16.5.0",
         "fastify": "^5.3.0",

--- a/src/models/comment.js
+++ b/src/models/comment.js
@@ -1,5 +1,13 @@
-import { GraphQLModel } from "@wizeworks/graphql-factory/*";
-const CommentModel: GraphQLModel = {
+/**
+ * @typedef {Object} GraphQLModel
+ * @property {string} name
+ * @property {Object} fields
+ */
+
+/**
+ * @type {GraphQLModel}
+ */
+const CommentModel = {
     name: 'Comment',
     fields: {
         id: { type: 'uuid', required: true, defaultValue: 'uuid()' },


### PR DESCRIPTION
Upgrade the @wizeworks/graphql-factory package to version 1.5.2 and reintroduce the CommentModel with a complete GraphQL structure.