### PR TITLE
Specify host for better accessibility in app.listen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wize-comment",
-    "version": "1.2.00",
+    "version": "1.2.01",
     "description": "WizeWorks Comment API",
     "main": "dist/server.js",
     "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -59,7 +59,7 @@ app.setNotFoundHandler((request, reply) => {
     reply.status(404).send({ error: 'Not Found' });
 });
 
-app.listen({ port: port }, (err, address) => {
+app.listen({ port: port, host: '0.0.0.0' }, (err, address) => {
     if (err) {
         Sentry.captureException(err);
         console.error(err);


### PR DESCRIPTION
Set the host to '0.0.0.0' in the app.listen method to improve accessibility. Update the version number to reflect this change.