### PR TITLE
feat: update dependencies and refactor server setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,10 @@
                 "@graphql-yoga/node": "^3.9.1",
                 "@sentry/node": "^9.13.0",
                 "@sentry/profiling-node": "^9.13.0",
-                "@wizeworks/graphql-factory-mongo": "^1.14.2",
+                "@wizeworks/graphql-factory-mongo": "^1.17.0",
                 "chalk": "^5.4.1",
                 "dotenv": "^16.5.0",
+                "express": "^5.1.0",
                 "graphql": "^16.10.0",
                 "graphql-scalars": "^1.24.2",
                 "graphql-subscriptions": "^3.0.0",
@@ -25,6 +26,7 @@
                 "@semantic-release/changelog": "^6.0.3",
                 "@semantic-release/git": "^10.0.1",
                 "@semantic-release/github": "^11.0.1",
+                "@types/express": "^5.0.1",
                 "@types/node": "^22.14.1",
                 "nodemon": "^3.1.9",
                 "semantic-release": "^24.2.3",
@@ -548,108 +550,11 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@fastify/ajv-compiler": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.2.tgz",
-            "integrity": "sha512-Rkiu/8wIjpsf46Rr+Fitd3HRP+VsxUFDDeag0hs9L0ksfnwx2g7SPQQTFL0E8Qv+rfXzQOxBJnjUB9ITUDjfWQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "ajv": "^8.12.0",
-                "ajv-formats": "^3.0.1",
-                "fast-uri": "^3.0.0"
-            }
-        },
         "node_modules/@fastify/busboy": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.1.1.tgz",
             "integrity": "sha512-5DGmA8FTdB2XbDeEwc/5ZXBl6UbBAyBOOLlPuBnZ/N1SwdH9Ii+cOX3tBROlDgcTXxjOYnLMVoKk9+FXAw0CJw==",
             "license": "MIT"
-        },
-        "node_modules/@fastify/error": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.1.0.tgz",
-            "integrity": "sha512-KeFcciOr1eo/YvIXHP65S94jfEEqn1RxTRBT1aJaHxY5FK0/GDXYozsQMMWlZoHgi8i0s+YtrLsgj/JkUUjSkQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/@fastify/fast-json-stringify-compiler": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.0.3.tgz",
-            "integrity": "sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "fast-json-stringify": "^6.0.0"
-            }
-        },
-        "node_modules/@fastify/forwarded": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.0.tgz",
-            "integrity": "sha512-kJExsp4JCms7ipzg7SJ3y8DwmePaELHxKYtg+tZow+k0znUTf3cb+npgyqm8+ATZOdmfgfydIebPDWM172wfyA==",
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/@fastify/merge-json-schemas": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
-            "integrity": "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "dequal": "^2.0.3"
-            }
-        },
-        "node_modules/@fastify/proxy-addr": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.0.0.tgz",
-            "integrity": "sha512-37qVVA1qZ5sgH7KpHkkC4z9SK6StIsIcOmpjvMPXNb3vx2GQxhZocogVYbr2PbbeLCQxYIPDok307xEvRZOzGA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@fastify/forwarded": "^3.0.0",
-                "ipaddr.js": "^2.1.0"
-            }
         },
         "node_modules/@graphql-tools/executor": {
             "version": "1.4.7",
@@ -2518,6 +2423,17 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/body-parser": {
+            "version": "1.19.5",
+            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+            "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/connect": "*",
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/connect": {
             "version": "3.4.38",
             "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -2526,6 +2442,45 @@
             "dependencies": {
                 "@types/node": "*"
             }
+        },
+        "node_modules/@types/express": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.1.tgz",
+            "integrity": "sha512-UZUw8vjpWFXuDnjFTh7/5c2TWDlQqeXHi6hcN7F2XSVT5P+WmUnnbFS3KA6Jnc6IsEqI2qCVu2bK0R0J4A8ZQQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/body-parser": "*",
+                "@types/express-serve-static-core": "^5.0.0",
+                "@types/serve-static": "*"
+            }
+        },
+        "node_modules/@types/express-serve-static-core": {
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
+            "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/qs": "*",
+                "@types/range-parser": "*",
+                "@types/send": "*"
+            }
+        },
+        "node_modules/@types/http-errors": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+            "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/mime": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+            "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/mysql": {
             "version": "2.15.26",
@@ -2570,6 +2525,43 @@
             "license": "MIT",
             "dependencies": {
                 "@types/pg": "*"
+            }
+        },
+        "node_modules/@types/qs": {
+            "version": "6.9.18",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
+            "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/range-parser": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/send": {
+            "version": "0.17.4",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+            "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mime": "^1",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/serve-static": {
+            "version": "1.15.7",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
+            "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/http-errors": "*",
+                "@types/node": "*",
+                "@types/send": "*"
             }
         },
         "node_modules/@types/shimmer": {
@@ -2684,9 +2676,9 @@
             }
         },
         "node_modules/@wizeworks/graphql-factory-mongo": {
-            "version": "1.14.2",
-            "resolved": "https://registry.npmjs.org/@wizeworks/graphql-factory-mongo/-/graphql-factory-mongo-1.14.2.tgz",
-            "integrity": "sha512-tVE8WnQ4QQF1va44WO4M0EGby3zA7XJPP0gSmldBDQiKRcCM7j9LRh+MOJayvRsr06RCIunz7D0WIpbZhx34zA==",
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/@wizeworks/graphql-factory-mongo/-/graphql-factory-mongo-1.17.0.tgz",
+            "integrity": "sha512-BaHwPoT6Gy8/+zsChwxdSEpFX1YVmkzWU4CU/gircI1t0uyIa50QTZbFXgmSu7E9FF4xSMBkH6mASht1Wlgyeg==",
             "license": "MIT",
             "dependencies": {
                 "graphql-scalars": "^1.24.2",
@@ -2696,18 +2688,23 @@
                 "node": ">=16.0.0"
             },
             "peerDependencies": {
-                "fastify": "^4.0.0 || ^5.0.0",
                 "graphql": "^15.0.0 || ^16.0.0 || ^17.0.0",
                 "graphql-subscriptions": "^3.0.0",
                 "mongodb": ">=6.0.0 <7.0.0"
             }
         },
-        "node_modules/abstract-logging": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
-            "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+        "node_modules/accepts": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+            "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
             "license": "MIT",
-            "peer": true
+            "dependencies": {
+                "mime-types": "^3.0.0",
+                "negotiator": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
         "node_modules/acorn": {
             "version": "8.14.1",
@@ -2765,41 +2762,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/ajv-formats": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "ajv": "^8.0.0"
-            },
-            "peerDependencies": {
-                "ajv": "^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "ajv": {
-                    "optional": true
-                }
             }
         },
         "node_modules/ansi-escapes": {
@@ -2910,27 +2872,6 @@
                 "node": ">=12.0.0"
             }
         },
-        "node_modules/atomic-sleep": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
-            "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/avvio": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.1.0.tgz",
-            "integrity": "sha512-fYASnYi600CsH/j9EQov7lECAniYiBFiiAtBNuZYLA2leLe9qOvZzqYHFjtIj6gD2VMoMLP14834LFWvr4IfDw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@fastify/error": "^4.0.0",
-                "fastq": "^1.17.1"
-            }
-        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2956,6 +2897,26 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/body-parser": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+            "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "^3.1.2",
+                "content-type": "^1.0.5",
+                "debug": "^4.4.0",
+                "http-errors": "^2.0.0",
+                "iconv-lite": "^0.6.3",
+                "on-finished": "^2.4.1",
+                "qs": "^6.14.0",
+                "raw-body": "^3.0.0",
+                "type-is": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/bottleneck": {
@@ -3013,6 +2974,44 @@
             },
             "engines": {
                 "node": ">=10.16.0"
+            }
+        },
+        "node_modules/bytes": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/callsites": {
@@ -3271,6 +3270,27 @@
                 "proto-list": "~1.2.1"
             }
         },
+        "node_modules/content-disposition": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+            "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/content-type": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/conventional-changelog-angular": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.0.0.tgz",
@@ -3342,14 +3362,13 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/cookie": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-            "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+        "node_modules/cookie-signature": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+            "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
             "license": "MIT",
-            "peer": true,
             "engines": {
-                "node": ">=18"
+                "node": ">=6.6.0"
             }
         },
         "node_modules/core-util-is": {
@@ -3476,14 +3495,13 @@
                 "node": ">=4.0.0"
             }
         },
-        "node_modules/dequal": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+        "node_modules/depd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
             "license": "MIT",
-            "peer": true,
             "engines": {
-                "node": ">=6"
+                "node": ">= 0.8"
             }
         },
         "node_modules/detect-libc": {
@@ -3552,6 +3570,20 @@
                 "node": ">=4"
             }
         },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/duplexer2": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -3571,6 +3603,12 @@
                 "safe-buffer": "^5.0.1"
             }
         },
+        "node_modules/ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+            "license": "MIT"
+        },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -3584,6 +3622,15 @@
             "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/encodeurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/env-ci": {
             "version": "11.1.0",
@@ -3776,6 +3823,36 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/esbuild": {
             "version": "0.25.3",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.3.tgz",
@@ -3827,6 +3904,12 @@
                 "node": ">=6"
             }
         },
+        "node_modules/escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+            "license": "MIT"
+        },
         "node_modules/escape-string-regexp": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -3838,6 +3921,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/execa": {
@@ -3864,6 +3956,57 @@
                 "url": "https://github.com/sindresorhus/execa?sponsor=1"
             }
         },
+        "node_modules/express": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+            "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "^2.0.0",
+                "body-parser": "^2.2.0",
+                "content-disposition": "^1.0.0",
+                "content-type": "^1.0.5",
+                "cookie": "^0.7.1",
+                "cookie-signature": "^1.2.1",
+                "debug": "^4.4.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "finalhandler": "^2.1.0",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.0",
+                "merge-descriptors": "^2.0.0",
+                "mime-types": "^3.0.0",
+                "on-finished": "^2.4.1",
+                "once": "^1.4.0",
+                "parseurl": "^1.3.3",
+                "proxy-addr": "^2.0.7",
+                "qs": "^6.14.0",
+                "range-parser": "^1.2.1",
+                "router": "^2.2.0",
+                "send": "^1.1.0",
+                "serve-static": "^2.2.0",
+                "statuses": "^2.0.1",
+                "type-is": "^2.0.1",
+                "vary": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/express/node_modules/cookie": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/fast-content-type-parse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
@@ -3887,13 +4030,6 @@
             "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
             "license": "MIT"
         },
-        "node_modules/fast-deep-equal": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/fast-glob": {
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -3911,31 +4047,6 @@
                 "node": ">=8.6.0"
             }
         },
-        "node_modules/fast-json-stringify": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-6.0.1.tgz",
-            "integrity": "sha512-s7SJE83QKBZwg54dIbD5rCtzOBVD43V1ReWXXYqBgwCwHLYAAT0RQc/FmrQglXqWPpz6omtryJQOau5jI4Nrvg==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@fastify/merge-json-schemas": "^0.2.0",
-                "ajv": "^8.12.0",
-                "ajv-formats": "^3.0.1",
-                "fast-uri": "^3.0.0",
-                "json-schema-ref-resolver": "^2.0.0",
-                "rfdc": "^1.2.0"
-            }
-        },
         "node_modules/fast-querystring": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
@@ -3944,33 +4055,6 @@
             "dependencies": {
                 "fast-decode-uri-component": "^1.0.1"
             }
-        },
-        "node_modules/fast-redact": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-            "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/fast-uri": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-            "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "BSD-3-Clause",
-            "peer": true
         },
         "node_modules/fast-url-parser": {
             "version": "1.1.3",
@@ -3987,44 +4071,11 @@
             "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
             "license": "MIT"
         },
-        "node_modules/fastify": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.3.2.tgz",
-            "integrity": "sha512-AIPqBgtqBAwkOkrnwesEE+dOyU30dQ4kh7udxeGVR05CRGwubZx+p2H8P0C4cRnQT0+EPK4VGea2DTL2RtWttg==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@fastify/ajv-compiler": "^4.0.0",
-                "@fastify/error": "^4.0.0",
-                "@fastify/fast-json-stringify-compiler": "^5.0.0",
-                "@fastify/proxy-addr": "^5.0.0",
-                "abstract-logging": "^2.0.1",
-                "avvio": "^9.0.0",
-                "fast-json-stringify": "^6.0.0",
-                "find-my-way": "^9.0.0",
-                "light-my-request": "^6.0.0",
-                "pino": "^9.0.0",
-                "process-warning": "^5.0.0",
-                "rfdc": "^1.3.1",
-                "secure-json-parse": "^4.0.0",
-                "semver": "^7.6.0",
-                "toad-cache": "^3.7.0"
-            }
-        },
         "node_modules/fastq": {
             "version": "1.19.1",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
             "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
@@ -4059,19 +4110,21 @@
                 "node": ">=8"
             }
         },
-        "node_modules/find-my-way": {
-            "version": "9.3.0",
-            "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.3.0.tgz",
-            "integrity": "sha512-eRoFWQw+Yv2tuYlK2pjFS2jGXSxSppAs3hSQjfxVKxM5amECzIgYYc1FEI8ZmhSh/Ig+FrKEz43NLRKJjYCZVg==",
+        "node_modules/finalhandler": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+            "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-querystring": "^1.0.0",
-                "safe-regex2": "^5.0.0"
+                "debug": "^4.4.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "on-finished": "^2.4.1",
+                "parseurl": "^1.3.3",
+                "statuses": "^2.0.1"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">= 0.8"
             }
         },
         "node_modules/find-up": {
@@ -4117,11 +4170,29 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/forwarded": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+            "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/forwarded-parse": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
             "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
             "license": "MIT"
+        },
+        "node_modules/fresh": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+            "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/from2": {
             "version": "2.3.0",
@@ -4194,6 +4265,43 @@
             "license": "ISC",
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/get-stream": {
@@ -4292,6 +4400,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/graceful-fs": {
@@ -4393,6 +4513,18 @@
                 "node": ">=4"
             }
         },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/hash-it": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/hash-it/-/hash-it-6.0.0.tgz",
@@ -4447,6 +4579,22 @@
                 "node": "^18.17.0 || >=20.5.0"
             }
         },
+        "node_modules/http-errors": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+            "license": "MIT",
+            "dependencies": {
+                "depd": "2.0.0",
+                "inherits": "2.0.4",
+                "setprototypeof": "1.2.0",
+                "statuses": "2.0.1",
+                "toidentifier": "1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/http-proxy-agent": {
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -4483,6 +4631,18 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=10.17.0"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/ignore": {
@@ -4593,7 +4753,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/ini": {
@@ -4618,16 +4777,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/ipaddr.js": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
-            "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 10"
             }
         },
         "node_modules/is-arrayish": {
@@ -4731,6 +4880,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-promise": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+            "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+            "license": "MIT"
+        },
         "node_modules/is-stream": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -4832,33 +4987,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/json-schema-ref-resolver": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-2.0.1.tgz",
-            "integrity": "sha512-HG0SIB9X4J8bwbxCbnd5FfPEbcXAJYTi1pBJeP/QPON+w8ovSME8iRG+ElHNxZNX2Qh6eYn1GdzJFS4cDFfx0Q==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "dequal": "^2.0.3"
-            }
-        },
-        "node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/jsonfile": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -4914,45 +5042,6 @@
                 "jwa": "^1.4.1",
                 "safe-buffer": "^5.0.1"
             }
-        },
-        "node_modules/light-my-request": {
-            "version": "6.6.0",
-            "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
-            "integrity": "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "BSD-3-Clause",
-            "peer": true,
-            "dependencies": {
-                "cookie": "^1.0.1",
-                "process-warning": "^4.0.0",
-                "set-cookie-parser": "^2.6.0"
-            }
-        },
-        "node_modules/light-my-request/node_modules/process-warning": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
-            "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/lines-and-columns": {
             "version": "1.2.4",
@@ -5130,6 +5219,24 @@
                 "marked": ">=1 <16"
             }
         },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/media-typer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/memory-pager": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
@@ -5141,6 +5248,18 @@
             "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
             "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
             "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/merge-descriptors": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+            "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -5194,6 +5313,27 @@
             },
             "engines": {
                 "node": ">=16"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+            "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/mimic-fn": {
@@ -5307,6 +5447,15 @@
                 "any-promise": "^1.0.0",
                 "object-assign": "^4.0.1",
                 "thenify-all": "^1.0.0"
+            }
+        },
+        "node_modules/negotiator": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/neo-async": {
@@ -8215,14 +8364,37 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/on-exit-leak-free": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
-            "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+        "node_modules/object-inspect": {
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
             "license": "MIT",
-            "peer": true,
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/on-finished": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+            "license": "MIT",
+            "dependencies": {
+                "ee-first": "1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
             }
         },
         "node_modules/onetime": {
@@ -8408,6 +8580,15 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/parseurl": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/path-exists": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -8433,6 +8614,15 @@
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "license": "MIT"
+        },
+        "node_modules/path-to-regexp": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+            "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            }
         },
         "node_modules/path-type": {
             "version": "4.0.0",
@@ -8504,63 +8694,6 @@
             "engines": {
                 "node": ">=4"
             }
-        },
-        "node_modules/pino": {
-            "version": "9.6.0",
-            "resolved": "https://registry.npmjs.org/pino/-/pino-9.6.0.tgz",
-            "integrity": "sha512-i85pKRCt4qMjZ1+L7sy2Ag4t1atFcdbEt76+7iRJn1g2BvsnRMGu9p8pivl9fs63M2kF/A0OacFZhTub+m/qMg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "atomic-sleep": "^1.0.0",
-                "fast-redact": "^3.1.1",
-                "on-exit-leak-free": "^2.1.0",
-                "pino-abstract-transport": "^2.0.0",
-                "pino-std-serializers": "^7.0.0",
-                "process-warning": "^4.0.0",
-                "quick-format-unescaped": "^4.0.3",
-                "real-require": "^0.2.0",
-                "safe-stable-stringify": "^2.3.1",
-                "sonic-boom": "^4.0.1",
-                "thread-stream": "^3.0.0"
-            },
-            "bin": {
-                "pino": "bin.js"
-            }
-        },
-        "node_modules/pino-abstract-transport": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
-            "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "split2": "^4.0.0"
-            }
-        },
-        "node_modules/pino-std-serializers": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-            "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/pino/node_modules/process-warning": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
-            "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/pkg-conf": {
             "version": "2.1.0",
@@ -8638,29 +8771,34 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/process-warning": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-            "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/proto-list": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
             "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/proxy-addr": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+            "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+            "license": "MIT",
+            "dependencies": {
+                "forwarded": "0.2.0",
+                "ipaddr.js": "1.9.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/proxy-addr/node_modules/ipaddr.js": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.10"
+            }
         },
         "node_modules/pstree.remy": {
             "version": "1.1.8",
@@ -8696,6 +8834,21 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/qs": {
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "side-channel": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -8717,12 +8870,29 @@
             ],
             "license": "MIT"
         },
-        "node_modules/quick-format-unescaped": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
-            "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+        "node_modules/range-parser": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
             "license": "MIT",
-            "peer": true
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/raw-body": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+            "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "3.1.2",
+                "http-errors": "2.0.0",
+                "iconv-lite": "0.6.3",
+                "unpipe": "1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/rc": {
             "version": "1.2.8",
@@ -8845,16 +9015,6 @@
                 "node": ">=8.10.0"
             }
         },
-        "node_modules/real-require": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
-            "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 12.13.0"
-            }
-        },
         "node_modules/registry-auth-token": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.0.tgz",
@@ -8874,16 +9034,6 @@
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
             "dev": true,
             "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/require-from-string": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-            "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8942,32 +9092,32 @@
                 "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
             }
         },
-        "node_modules/ret": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
-            "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/reusify": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
             "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/rfdc": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-            "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+        "node_modules/router": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+            "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
             "license": "MIT",
-            "peer": true
+            "dependencies": {
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "is-promise": "^4.0.0",
+                "parseurl": "^1.3.3",
+                "path-to-regexp": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
@@ -9013,52 +9163,11 @@
             ],
             "license": "MIT"
         },
-        "node_modules/safe-regex2": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.0.0.tgz",
-            "integrity": "sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "ret": "~0.5.0"
-            }
-        },
-        "node_modules/safe-stable-stringify": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
-            "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/secure-json-parse": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.0.0.tgz",
-            "integrity": "sha512-dxtLJO6sc35jWidmLxo7ij+Eg48PM/kleBsxpC8QJE0qJICe+KawkDQmvCMZUr9u7WKVHgMW6vy3fQ7zMiFZMA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "BSD-3-Clause",
-            "peer": true
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "license": "MIT"
         },
         "node_modules/semantic-release": {
             "version": "24.2.3",
@@ -9350,12 +9459,48 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/set-cookie-parser": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-            "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+        "node_modules/send": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+            "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
             "license": "MIT",
-            "peer": true
+            "dependencies": {
+                "debug": "^4.3.5",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.0",
+                "mime-types": "^3.0.1",
+                "ms": "^2.1.3",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "statuses": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/serve-static": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+            "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+            "license": "MIT",
+            "dependencies": {
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "parseurl": "^1.3.3",
+                "send": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/setprototypeof": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+            "license": "ISC"
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
@@ -9385,6 +9530,78 @@
             "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
             "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
             "license": "BSD-2-Clause"
+        },
+        "node_modules/side-channel": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3",
+                "side-channel-list": "^1.0.0",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-list": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/signal-exit": {
             "version": "3.0.7",
@@ -9515,16 +9732,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/sonic-boom": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
-            "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "atomic-sleep": "^1.0.0"
-            }
-        },
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -9587,14 +9794,13 @@
             "dev": true,
             "license": "CC0-1.0"
         },
-        "node_modules/split2": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-            "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-            "license": "ISC",
-            "peer": true,
+        "node_modules/statuses": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+            "license": "MIT",
             "engines": {
-                "node": ">= 10.x"
+                "node": ">= 0.8"
             }
         },
         "node_modules/stream-combiner2": {
@@ -9861,16 +10067,6 @@
                 "node": ">=0.8"
             }
         },
-        "node_modules/thread-stream": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-            "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "real-require": "^0.2.0"
-            }
-        },
         "node_modules/through2": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
@@ -9911,14 +10107,13 @@
                 "node": ">=8.0"
             }
         },
-        "node_modules/toad-cache": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
-            "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
+        "node_modules/toidentifier": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
             "license": "MIT",
-            "peer": true,
             "engines": {
-                "node": ">=12"
+                "node": ">=0.6"
             }
         },
         "node_modules/touch": {
@@ -10039,6 +10234,20 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/type-is": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+            "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^1.0.5",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/typescript": {
             "version": "5.8.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -10136,6 +10345,15 @@
                 "node": ">= 10.0.0"
             }
         },
+        "node_modules/unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/url-join": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
@@ -10184,6 +10402,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/web-streams-polyfill": {
@@ -10270,6 +10497,12 @@
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "license": "ISC"
         },
         "node_modules/xtend": {
             "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,10 @@
         "@graphql-yoga/node": "^3.9.1",
         "@sentry/node": "^9.13.0",
         "@sentry/profiling-node": "^9.13.0",
-        "@wizeworks/graphql-factory-mongo": "^1.14.2",
+        "@wizeworks/graphql-factory-mongo": "^1.17.0",
         "chalk": "^5.4.1",
         "dotenv": "^16.5.0",
+        "express": "^5.1.0",
         "graphql": "^16.10.0",
         "graphql-scalars": "^1.24.2",
         "graphql-subscriptions": "^3.0.0",
@@ -28,12 +29,13 @@
         "mongodb": "^6.16.0"
     },
     "devDependencies": {
-        "semantic-release": "^24.2.3",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^11.0.1",
+        "@types/express": "^5.0.1",
         "@types/node": "^22.14.1",
         "nodemon": "^3.1.9",
+        "semantic-release": "^24.2.3",
         "ts-node": "^10.9.2",
         "tsx": "^4.19.3",
         "typescript": "^5.8.3"

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,30 +2,42 @@
 
 import './config/dotenv';
 
-import { createServer } from 'node:http';
+import express from 'express';
 import { MongoClient } from 'mongodb';
 import { createYoga } from 'graphql-yoga';
-import { createServerSchema, createServerContext } from '@wizeworks/graphql-factory-mongo';
+import { createServerSchema, createServerContext, registerSchemaRoutes } from '@wizeworks/graphql-factory-mongo';
 
 const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
-const MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/wize-comment';
-console.log('GraphQL resolved from:', require.resolve('graphql'));
-const start = async () => {
-    const mongoClient = new MongoClient(MONGO_URI);
+const MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/';
+
+const mongoClient = new MongoClient(MONGO_URI);
+
+(async () => {
     await mongoClient.connect();
 
     const yoga = createYoga({
         graphqlEndpoint: '/graphql',
         schema: (args) => createServerSchema(args.request, mongoClient),
-        context: (args) => createServerContext(args.request, mongoClient),
+        context: async ({request}) => {
+            const baseContext = await createServerContext(request, mongoClient);
+            return {
+                ...baseContext,
+                dbName: 'wize-comments',
+            };
+        },
         graphiql: true
     });
 
-    const server = createServer(yoga);
+    const app = express();
+    app.use(express.json());
+    
+    const schema = registerSchemaRoutes(app, mongoClient);
 
-    server.listen(port, () => {
+
+    // Use Yoga as middleware in Express
+    app.use(yoga.graphqlEndpoint, yoga);
+
+    app.listen(port, () => {
         console.log(`🚀 wize-comment API ready at http://localhost:${port}/graphql`);
     });
-};
-
-start();
+})();

--- a/src/types/avail.json
+++ b/src/types/avail.json
@@ -1,0 +1,8 @@
+{
+    "tables": [
+        "content",
+        "status",
+        "category"
+
+    ]
+}


### PR DESCRIPTION
- Updated @wizeworks/graphql-factory-mongo to version 1.17.0.
- Added express as a dependency and integrated it into the server setup.
- Refactored server initialization to use express middleware for GraphQL.
- Enhanced context creation to include dbName in the GraphQL context.
- Created a new avail.json file to define database tables.