### PR TITLE
fix: Add GitHub token to kubelogin installation step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,6 +107,8 @@ jobs:
 
       - name: Install kubelogin
         uses: azure/use-kubelogin@v1
+        env:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
         
 
       - name: Set AKS Context


### PR DESCRIPTION
Include the GitHub token as an environment variable during the kubelogin installation to ensure proper authentication.